### PR TITLE
Disable SwiftLint rules for generated enum transformers,

### DIFF
--- a/Sources/Templates/LightTransformer.swifttemplate
+++ b/Sources/Templates/LightTransformer.swifttemplate
@@ -69,6 +69,9 @@ import EEUtilities
 // No raw type detected.
 // sourcery:end
 <%_ continue } -%>
+// swiftlint:disable line_length
+// swiftlint:disable type_name
+// swiftlint:disable function_body_length
 struct <%= name %>: LightTransformer {
     typealias T = <%= type.name %>
 
@@ -98,6 +101,9 @@ struct <%= name %>: LightTransformer {
         }
     }
 }
+// swiftlint:enable line_length
+// swiftlint:enable type_name
+// swiftlint:enable function_body_length
 
 // sourcery:end
 <% } -%>
@@ -120,6 +126,8 @@ import CoreGraphics
 import EEUtilities
 
 // swiftlint:disable line_length
+// swiftlint:disable type_name
+// swiftlint:disable function_body_length
 struct <%= name %>: LightTransformer {
     typealias T = <%= type.name %>
 
@@ -188,6 +196,8 @@ struct <%= name %>: LightTransformer {
     }
 }
 // swiftlint:enable line_length
+// swiftlint:enable type_name
+// swiftlint:enable function_body_length
 
 // sourcery:end
 <% } -%>

--- a/Sources/Templates/Transformer.swifttemplate
+++ b/Sources/Templates/Transformer.swifttemplate
@@ -69,6 +69,9 @@ import EEUtilities
 // No raw type detected.
 // sourcery:end
 <%_ continue } -%>
+// swiftlint:disable line_length
+// swiftlint:disable type_name
+// swiftlint:disable function_body_length
 struct <%= name %><From>: FullTransformer {
     typealias Source = From
     typealias Destination = <%= type.name %>
@@ -97,6 +100,9 @@ struct <%= name %><From>: FullTransformer {
         }
     }
 }
+// swiftlint:enable line_length
+// swiftlint:enable type_name
+// swiftlint:enable function_body_length
 
 // sourcery:end
 <% } -%>
@@ -119,6 +125,8 @@ import CoreGraphics
 import EEUtilities
 
 // swiftlint:disable line_length
+// swiftlint:disable type_name
+// swiftlint:disable function_body_length
 struct <%= name %>: FullTransformer {
     typealias Source = Any
     typealias Destination = <%= type.name %>
@@ -223,6 +231,8 @@ struct <%= name %>: FullTransformer {
     }
 }
 // swiftlint:enable line_length
+// swiftlint:enable type_name
+// swiftlint:enable function_body_length
 
 // sourcery:end
 <% } -%>


### PR DESCRIPTION
Disable SwiftLint rules for generated enum transformers,
Disable type_name and function_body_length SwiftLint rules for generated struct/class transformers
